### PR TITLE
Add UI tweaks and Kaito comments

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -20,7 +20,7 @@ export default function Home() {
     <div className="min-h-screen flex flex-col font-sans text-white bg-gradient-to-br from-zinc-900 to-zinc-800">
       <header className="p-6 text-center">
         <h1 className="text-3xl font-bold">Espresso Flex Cards</h1>
-        <p className="text-gray-400">Crypto mindshare at a glance</p>
+        <p className="text-gray-400">Powered by Kaito</p>
       </header>
       <main className="flex-grow px-4 pb-8" id="main">
         <form onSubmit={addTopic} className="mb-6 flex justify-center">

--- a/src/api/kaito.ts
+++ b/src/api/kaito.ts
@@ -1,3 +1,4 @@
+// Base URL for all Kaito API requests
 const BASE_URL = 'https://api.kaito.ai/v1'
 
 interface MindshareData {
@@ -5,6 +6,10 @@ interface MindshareData {
   trend: 'positive' | 'neutral' | 'negative'
 }
 
+/**
+ * Fetch mindshare information for a given topic from Kaito.
+ * The API key is read from the VITE_KAITO_API_KEY environment variable.
+ */
 export async function fetchMindshare(topic: string): Promise<MindshareData> {
   const apiKey = import.meta.env.VITE_KAITO_API_KEY
   if (!apiKey) throw new Error('Missing KAITO API Key')

--- a/src/components/FlexCard.tsx
+++ b/src/components/FlexCard.tsx
@@ -49,7 +49,11 @@ export default function FlexCard({ topic }: Props) {
     <div
       className="rounded-xl bg-white/10 backdrop-blur-md p-4 transition-transform transform hover:scale-105 hover:shadow-xl"
     >
-      {loading && <p>Loading...</p>}
+      {loading && (
+        <div className="flex items-center justify-center h-24">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
+        </div>
+      )}
       {error && <p className="text-red-500">{error}</p>}
       {!loading && !error && data && (
         <>


### PR DESCRIPTION
## Summary
- tweak subtitle on home page
- show a spinner while fetching data
- document Kaito API helper

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm run build` *(fails: missing modules 'react' and others)*

------
https://chatgpt.com/codex/tasks/task_e_686e01c658948321bd40419e012299d5