### PR TITLE
Implement glassmorphic redesign

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,11 @@
 import { useState, type FormEvent } from 'react'
-// We will define fetchYaps inline for clarity, or you can update your ./api/kaito file.
-import FlexCard from './components/FlexCard'
+import Navbar from './components/Navbar'
+import Hero from './components/Hero'
+import DashboardLayout from './components/DashboardLayout'
+import InsightsModal from './components/InsightsModal'
+import Footer from './components/Footer'
+import type { KaitoYapData } from './types'
 
-export interface KaitoYapData {
-  user_id: string;
-  username: string;
-  yaps_all: number;
-  yaps_l24h: number;
-  yaps_l48h: number;
-  yaps_l7d: number;
-  yaps_l30d: number;
-  yaps_l3m: number;
-  yaps_l6m: number;
-  [key: string]: unknown;
-}
 
 // Proxy endpoint: /api/yaps?username=...
 export async function fetchYaps(username: string): Promise<KaitoYapData> {
@@ -35,6 +27,7 @@ export default function App() {
   const [data, setData] = useState<KaitoYapData | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
+  const [showInsights, setShowInsights] = useState(false)
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -54,26 +47,22 @@ export default function App() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
-      <div className="w-full max-w-md space-y-4">
-        <form onSubmit={handleSubmit} className="flex space-x-2">
-          <input
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            placeholder="Enter X username"
-            className="flex-grow rounded border border-gray-300 px-3 py-2 focus:outline-none"
+    <div>
+      <Navbar />
+      <Hero username={username} onUsernameChange={setUsername} onSubmit={handleSubmit} />
+      {loading && <p className="text-center mt-4">Loading...</p>}
+      {error && <p className="text-center text-red-500 mt-4">{error}</p>}
+      {data && (
+        <>
+          <DashboardLayout data={data} onShowInsights={() => setShowInsights(true)} />
+          <InsightsModal
+            open={showInsights}
+            onClose={() => setShowInsights(false)}
+            points={[data.yaps_l24h, data.yaps_l7d, data.yaps_l30d, data.yaps_l6m]}
           />
-          <button
-            type="submit"
-            className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
-          >
-            Submit
-          </button>
-        </form>
-        {loading && <p className="text-center">Loading...</p>}
-        {error && <p className="text-center text-red-500">{error}</p>}
-        {data && <FlexCard data={data} />}
-      </div>
+        </>
+      )}
+      <Footer />
     </div>
   )
 }

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -1,0 +1,25 @@
+import type { KaitoYapData } from '../types'
+import YapCard from './YapCard'
+
+interface DashboardLayoutProps {
+  data: KaitoYapData
+  onShowInsights: () => void
+}
+
+export default function DashboardLayout({ data, onShowInsights }: DashboardLayoutProps) {
+  return (
+    <div className="max-w-7xl mx-auto mt-10 px-4 grid grid-cols-1 md:grid-cols-[300px_1fr] gap-6">
+      <aside className="glass p-4">
+        <h2 className="font-semibold mb-2">Trending</h2>
+        <ul className="space-y-1 text-sm text-gray-300">
+          <li>#coffee</li>
+          <li>#yaps</li>
+          <li>#analytics</li>
+        </ul>
+      </aside>
+      <main className="grid gap-4 sm:grid-cols-2">
+        <YapCard data={data} onShowInsights={onShowInsights} />
+      </main>
+    </div>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="glass bg-white/10 backdrop-blur-md border-t border-white/20 p-4 text-sm text-gray-400 text-center mt-10">
+      Powered by Kaito Yaps API • Built by Your Name
+    </footer>
+  )
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,41 @@
+import { type FormEvent, useEffect, useState } from 'react'
+
+interface HeroProps {
+  username: string
+  onUsernameChange: (v: string) => void
+  onSubmit: (e: FormEvent<HTMLFormElement>) => void
+}
+
+export default function Hero({ username, onUsernameChange, onSubmit }: HeroProps) {
+  const [visible, setVisible] = useState(false)
+  useEffect(() => {
+    setVisible(true)
+  }, [])
+
+  return (
+    <section className="min-h-screen flex items-center justify-center pt-16">
+      <div
+        className={`text-center transition-all duration-700 ease-out transform ${
+          visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
+        }`}
+      >
+        <h1 className="text-5xl md:text-7xl font-extrabold text-white">Espresso Yaps Analytics</h1>
+        <p className="mt-4 text-lg text-gray-300">Tokenized attention for X at a glance</p>
+        <form
+          onSubmit={onSubmit}
+          className="mt-8 max-w-lg mx-auto bg-white/20 backdrop-blur-md border border-white/30 rounded-full p-4 flex items-center"
+        >
+          <input
+            value={username}
+            onChange={(e) => onUsernameChange(e.target.value)}
+            placeholder="Search username"
+            className="flex-grow bg-transparent placeholder-gray-400 focus:outline-none px-3"
+          />
+          <button type="submit" className="text-white hover:underline">
+            Search
+          </button>
+        </form>
+      </div>
+    </section>
+  )
+}

--- a/src/components/InsightsModal.tsx
+++ b/src/components/InsightsModal.tsx
@@ -1,0 +1,33 @@
+interface InsightsModalProps {
+  open: boolean
+  onClose: () => void
+  points: number[]
+}
+
+export default function InsightsModal({ open, onClose, points }: InsightsModalProps) {
+  if (!open) return null
+
+  const width = 400
+  const height = 200
+  const max = Math.max(...points, 1)
+  const step = width / (points.length - 1)
+  const d = points
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${i * step},${height - (p / max) * height}`)
+    .join(' ')
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white/5 backdrop-blur-xl border border-white/20 rounded-3xl p-8 max-w-2xl glass relative">
+        <button
+          className="absolute top-4 right-4 text-sm text-gray-300 hover:underline"
+          onClick={onClose}
+        >
+          Close
+        </button>
+        <svg width={width} height={height} className="w-full h-48 mt-4">
+          <path d={d} fill="none" stroke="#a5f3fc" strokeWidth="2" />
+        </svg>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+
+export default function Navbar() {
+  const [open, setOpen] = useState(false)
+  const links = [
+    { href: '#', label: 'Dashboard' },
+    { href: '#', label: 'Groups' },
+    { href: '#', label: 'Insights' },
+  ]
+
+  return (
+    <nav className="fixed top-0 inset-x-0 h-16 glass bg-white/10 backdrop-blur-md flex items-center justify-between px-6 z-50">
+      <div className="font-bold text-xl">EspressoYaps</div>
+      <div className="hidden md:flex space-x-6">
+        {links.map((l) => (
+          <a key={l.label} href={l.href} className="hover:underline">
+            {l.label}
+          </a>
+        ))}
+      </div>
+      <button
+        aria-label="Menu"
+        className="md:hidden focus:outline-none"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-6 w-6 text-white"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          {open ? (
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          ) : (
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 6h16M4 12h16M4 18h16"
+            />
+          )}
+        </svg>
+      </button>
+      {open && (
+        <div className="absolute top-16 right-4 w-40 space-y-2 glass bg-white/10 backdrop-blur-md p-4 md:hidden">
+          {links.map((l) => (
+            <a
+              key={l.label}
+              href={l.href}
+              className="block hover:underline"
+              onClick={() => setOpen(false)}
+            >
+              {l.label}
+            </a>
+          ))}
+        </div>
+      )}
+    </nav>
+  )
+}

--- a/src/components/YapCard.tsx
+++ b/src/components/YapCard.tsx
@@ -1,0 +1,40 @@
+import type { KaitoYapData } from '../types'
+
+interface Props {
+  data: KaitoYapData
+  onShowInsights: () => void
+}
+
+export default function YapCard({ data, onShowInsights }: Props) {
+  return (
+    <div className="glass p-6 transition transform hover:scale-105">
+      <header className="mb-4">
+        <p className="font-semibold">
+          {data.username} <span className="text-gray-400">({data.user_id})</span>
+        </p>
+      </header>
+      <div className="text-4xl text-green-300 font-bold mb-4">{data.yaps_all}</div>
+      <div className="grid grid-cols-2 gap-2 text-sm">
+        <div>
+          <p className="text-gray-300">24h</p>
+          <p className="font-mono text-white">{data.yaps_l24h}</p>
+        </div>
+        <div>
+          <p className="text-gray-300">48h</p>
+          <p className="font-mono text-white">{data.yaps_l48h}</p>
+        </div>
+        <div>
+          <p className="text-gray-300">7d</p>
+          <p className="font-mono text-white">{data.yaps_l7d}</p>
+        </div>
+        <div>
+          <p className="text-gray-300">30d</p>
+          <p className="font-mono text-white">{data.yaps_l30d}</p>
+        </div>
+      </div>
+      <button className="mt-4 text-sm text-blue-300 hover:underline" onClick={onShowInsights}>
+        View Insights
+      </button>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,15 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-gradient-to-b from-gray-900 to-black text-white font-sans min-h-screen;
+  font-family: 'Inter', sans-serif;
+}
+
+@layer components {
+  .glass {
+    @apply bg-white/10 backdrop-blur-lg border border-white/20 rounded-2xl shadow-lg;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,12 @@
+export interface KaitoYapData {
+  user_id: string
+  username: string
+  yaps_all: number
+  yaps_l24h: number
+  yaps_l48h: number
+  yaps_l7d: number
+  yaps_l30d: number
+  yaps_l3m: number
+  yaps_l6m: number
+  [key: string]: unknown
+}


### PR DESCRIPTION
## Summary
- add global Inter font, gradient background, and glass utility
- create new components: Navbar, Hero, Dashboard layout, YapCard, InsightsModal, Footer
- update App to use new components

## Testing
- `pnpm run build` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6870b59faf388321a7178735a1485569